### PR TITLE
4.0 Work

### DIFF
--- a/dom-events.js
+++ b/dom-events.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var domMutate = require('can-dom-mutate');
+
+function makeMutationEvent (defaultEventType, subscription) {
+	var elementSubscriptions = new Map();
+	return {
+		_subscriptions: elementSubscriptions,
+		defaultEventType: defaultEventType,
+		addEventListener: function (target, eventType, handler) {
+			var dispatch = this.dispatch;
+			var data = elementSubscriptions.get(target);
+			if (!data) {
+				data = {
+					removeListener: null,
+					listeners: new Set()
+				};
+				elementSubscriptions.set(target, data);
+			}
+
+			if (data.listeners.size === 0) {
+				data.removeListener = subscription(target, function (mutation) {
+					var eventData = {type: eventType};
+					for (var key in mutation) {
+						eventData[key] = mutation[key];
+					}
+
+					dispatch(target, eventData);
+				});
+			}
+
+			data.listeners.add(handler);
+			target.addEventListener(eventType, handler);
+		},
+		removeEventListener: function (target, eventType, handler) {
+			target.removeEventListener(eventType, handler);
+			var data = elementSubscriptions.get(target);
+			if (data) {
+				data.listeners['delete'](handler);
+				if (data.listeners.size === 0) {
+					data.removeListener();
+					elementSubscriptions['delete'](target);
+				}
+			}		
+		}
+	};
+}
+
+module.exports = {
+	attributes: makeMutationEvent('attributes', domMutate.onNodeAttributeChange),
+	inserted: makeMutationEvent('inserted', domMutate.onNodeInsertion),
+	removed: makeMutationEvent('removed', domMutate.onNodeRemoval)
+};

--- a/node.js
+++ b/node.js
@@ -38,6 +38,14 @@ var compat = {
 			domMutate.dispatchNodeAttributeChange(this, name, oldAttributeValue);
 		}
 		return result;
+	},
+	removeAttribute: function (name) {
+		var oldAttributeValue = this.getAttribute(name);
+		var result = this.removeAttribute(name);
+		if (oldAttributeValue) {
+			domMutate.dispatchNodeAttributeChange(this, name, oldAttributeValue);
+		}
+		return result;	
 	}
 };
 
@@ -60,7 +68,7 @@ compatData.forEach(function (pair) {
 });
 
 var normal = {};
-var nodeMethods = ['appendChild', 'insertBefore', 'removeChild', 'replaceChild', 'setAttribute'];
+var nodeMethods = ['appendChild', 'insertBefore', 'removeChild', 'replaceChild', 'setAttribute', 'removeAttribute'];
 nodeMethods.forEach(function (methodName) {
 	normal[methodName] = function () {
 		return this[methodName].apply(this, arguments);
@@ -143,6 +151,17 @@ var mutate = {};
 * @param {Element} element The element on which to set the attribute.
 * @param {String} name The name of the attribute to set.
 * @param {String} value The value to set on the attribute.
+*/
+
+/**
+* @function can-dom-mutate/node.removeAttribute removeAttribute
+*
+* Removes an attribute from an element, effectively `Element.prototype.removeAttribute`.
+*
+* @signature `mutate.removeAttribute.call(element, name, value)`
+* @parent can-dom-mutate.node
+* @param {Element} element The element from which to remove the attribute.
+* @param {String} name The name of the attribute to remove.
 */
 
 function setMutateStrategy(observer) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "url": "https://github.com/canjs/can-dom-mutate/issues"
   },
   "dependencies": {
-    "can-cid": "^1.1.1",
     "can-globals": "<2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
     "url": "git://github.com/canjs/can-dom-mutate.git"
   },
   "scripts": {
-    "install-canary": "npm install --no-shrinkwrap",
-    "install-locked": "npm install",
     "jshint": "jshint ./*.js ./test/*.js --config",
     "lint": "fixpack && npm run jshint",
     "preversion": "npm test",


### PR DESCRIPTION
can-dom-mutate#master made the switch to using WeakMaps instead of `dom-data`. This branch exists to allow 4.0 work on other packages to point to this branch instead of doing prerelease dances.