### PR TITLE
Use can-globals/document/document to get the global document

### DIFF
--- a/-util.js
+++ b/-util.js
@@ -1,3 +1,5 @@
+var getDocument = require("can-globals/document/document");
+
 var push = Array.prototype.push;
 
 function eliminate(array, item) {
@@ -8,19 +10,15 @@ function eliminate(array, item) {
 }
 
 function isInDocument (node) {
-	var root = node.ownerDocument.documentElement;
+	var root = getDocument().documentElement;
 	if (root === node) {
 		return true;
 	}
 	return root.contains(node);
 }
 
-function getDocument(target) {
-	return target.ownerDocument || target.document || target;
-}
-
 function isDocumentElement (node) {
-	return getDocument(node).documentElement === node;
+	return getDocument().documentElement === node;
 }
 
 function isFragment (node) {

--- a/can-dom-mutate.js
+++ b/can-dom-mutate.js
@@ -82,7 +82,7 @@ function batch(processBatchItems, shouldDeduplicate) {
 }
 
 function getDocumentListeners (target, key) {
-	var doc = getDocument(target);
+	var doc = getDocument();
 	var data = getRelatedData(doc, key);
 	if (data) {
 		return data.listeners;
@@ -90,7 +90,7 @@ function getDocumentListeners (target, key) {
 }
 
 function getTargetListeners (target, key) {
-	var doc = getDocument(target);
+	var doc = getDocument();
 	var targetListenersMap = getRelatedData(doc, key);
 	if (!targetListenersMap) {
 		return;
@@ -100,7 +100,7 @@ function getTargetListeners (target, key) {
 }
 
 function addTargetListener (target, key, listener) {
-	var doc = getDocument(target);
+	var doc = getDocument();
 	var targetListenersMap = getRelatedData(doc, key);
 	if (!targetListenersMap) {
 		targetListenersMap = new Map();
@@ -115,7 +115,7 @@ function addTargetListener (target, key, listener) {
 }
 
 function removeTargetListener (target, key, listener) {
-	var doc = getDocument(target);
+	var doc = getDocument();
 	var targetListenersMap = getRelatedData(doc, key);
 	if (!targetListenersMap) {
 		return;
@@ -260,7 +260,7 @@ function addNodeListener(listenerKey, observerKey, isAttributes) {
 		if (isAttributes) {
 			stopObserving = observeMutations(target, observerKey, attributeMutationConfig, handleAttributeMutations);
 		} else {
-			stopObserving = observeMutations(getDocument(target), observerKey, treeMutationConfig, handleTreeMutations);
+			stopObserving = observeMutations(getDocument(), observerKey, treeMutationConfig, handleTreeMutations);
 		}
 
 		addTargetListener(target, listenerKey, listener);
@@ -277,7 +277,7 @@ function addGlobalListener(globalDataKey, addNodeListener) {
 			throw new Error('Global mutation listeners must pass a documentElement');
 		}
 
-		var doc = getDocument(documentElement);
+		var doc = getDocument();
 		var documentData = getRelatedData(doc, globalDataKey);
 		if (!documentData) {
 			documentData = {listeners: []};

--- a/test/can-dom-mutate-test.js
+++ b/test/can-dom-mutate-test.js
@@ -128,4 +128,22 @@ moduleMutationObserver('can-dom-mutate', function () {
 		parent.appendChild(child);
 		node.removeChild.call(parent, child);
 	});
+
+	test('onNodeInsertion should be called when that node is inserted into a different document', function(assert){
+		var done = assert.async();
+		var parent = testUtils.getFixture();
+
+		var doc1 = document.implementation.createHTMLDocument('doc1');
+		var child = doc1.createElement('div');
+
+		var undo = domMutate.onNodeInsertion(child, function (mutation) {
+			var node = mutation.target;
+			assert.equal(node, child, 'Node should be the inserted child');
+
+			undo();
+			done();
+		});
+
+		node.appendChild.call(parent, child);
+	});
 });


### PR DESCRIPTION
Rather than checking if a node is inserted into its ownerDocument, check
if it is inserted into the global document. This means you can create
nodes from other documents and then insert them into the global document
and have onNodeInsertion work. This is what happens in ssr.