### PR TITLE
Prevent leaks caused by onNodeRemoval being called on a fragment

### DIFF
--- a/-util.js
+++ b/-util.js
@@ -11,7 +11,7 @@ function eliminate(array, item) {
 }
 
 function isInDocument (node) {
-	var root = getDocument().documentElement;
+	var root = getDocument();
 	if (root === node) {
 		return true;
 	}

--- a/can-dom-mutate.js
+++ b/can-dom-mutate.js
@@ -257,6 +257,15 @@ var attributeMutationConfig = {
 
 function addNodeListener(listenerKey, observerKey, isAttributes) {
 	return subscription(function _addNodeListener(target, listener) {
+		// DocumentFragment
+		if(target.nodeType === 11) {
+			// This returns a noop without actually doing anything.
+			// We should probably warn about passing a DocumentFragment here,
+			// but since can-stache does so currently we are ignoring until that is
+			// fixed.
+			return Function.prototype;
+		}
+
 		var stopObserving;
 		if (isAttributes) {
 			stopObserving = observeMutations(target, observerKey, attributeMutationConfig, handleAttributeMutations);

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -1,5 +1,6 @@
 var unit = require('steal-qunit');
 var domMutate = require('../can-dom-mutate');
+var getDocument = require('can-globals/document/document');
 var node = require('../node');
 var testUtils = require('./test-utils');
 
@@ -340,5 +341,20 @@ moduleWithoutMutationObserver('can-dom-mutate/node (not in document)', function 
 		node.replaceChild.call(fragment, child, oldChild);
 		undoRemoval();
 		undoInsertion();
+	});
+
+	test('removeChild on the documentElement', function(assert) {
+		var done = assert.async();
+		var doc1 = document.implementation.createHTMLDocument('doc1');
+
+		var undo = domMutate.onNodeRemoval(doc1.documentElement, function() {
+			assert.ok(true, 'this was called');
+			undo();
+			done();
+		});
+
+		getDocument(doc1);
+		node.removeChild.call(doc1, doc1.documentElement);
+		getDocument(document);
 	});
 });


### PR DESCRIPTION
Currently can-stache some times passes a DocumentFragment to
can-view-live which then calls domMutate.onNodeRemoval(frag);

Since you can't observe a fragment being removed (it is never in the
document), this change makes it so that `domMutate.onNodeRemoval(frag)`
is a noop.