### PR TITLE
improves performance slightly and supports listening to text nodes

### DIFF
--- a/-util.js
+++ b/-util.js
@@ -1,12 +1,16 @@
 "use strict";
 var getDocument = require("can-globals/document/document");
 
-var push = Array.prototype.push;
-
 function eliminate(array, item) {
 	var index = array.indexOf(item);
 	if (index >= 0) {
 		array.splice(index, 1);
+	}
+}
+
+function addToSet(items, set) {
+	for(var i =0, length = items.length; i < length; i++ ) {
+		set.add(items[i]);
 	}
 }
 
@@ -46,18 +50,69 @@ function getParents (node) {
 	return nodes;
 }
 
-function getAllNodes (node) {
-	var nodes = getParents(node);
-	var cLen = nodes.length;
-	for (var c = 0; c < cLen; c++) {
-		var element = nodes[c];
-		if (element.getElementsByTagName) {
-			var descendants = element.getElementsByTagName('*');
-			push.apply(nodes, descendants);
-		}
+
+function getNodesLegacyB(node) {
+	var skip, tmp;
+
+	var depth = 0;
+
+	var items = isFragment(node) ? [] : [node];
+	if(node.firstChild == null) {
+		return items;
 	}
 
-	return nodes;
+	// Always start with the initial element.
+	do {
+		if ( !skip && (tmp = node.firstChild) ) {
+			depth++;
+			items.push(tmp);
+		} else if ( tmp = node.nextSibling ) {
+			skip = false;
+			items.push(tmp);
+		} else {
+			// Skipped or no first child and no next sibling, so traverse upwards,
+			tmp = node.parentNode;
+			// and decrement the depth.
+			depth--;
+			// Enable skipping, so that in the next loop iteration, the children of
+			// the now-current node (parent node) aren't processed again.
+			skip = true;
+		}
+
+		// Instead of setting node explicitly in each conditional block, use the
+		// tmp var and set it here.
+		node = tmp;
+
+		// Stop if depth comes back to 0 (or goes below zero, in conditions where
+		// the passed node has neither children nore next siblings).
+	} while ( depth > 0 );
+
+	return items;
+}
+
+function getNodesWithTreeWalker(rootNode) {
+	var result = isFragment(rootNode) ? [] : [rootNode];
+
+	var walker = getDocument().createTreeWalker(
+		rootNode,
+		NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
+		null,
+		false
+	);
+
+	var node;
+	while(node = walker.nextNode()) {
+		result.push(node);
+	}
+	return result;
+}
+
+function getAllNodes (node) {
+	if( getDocument().createTreeWalker !== undefined ) {
+		return getNodesWithTreeWalker(node);
+	} else {
+		return getNodesLegacyB(node);
+	}
 }
 
 function subscription (fn) {
@@ -85,5 +140,6 @@ module.exports = {
 	getParents: getParents,
 	getAllNodes: getAllNodes,
 	getChildren: getChildren,
-	subscription: subscription
+	subscription: subscription,
+	addToSet: addToSet
 };

--- a/can-dom-mutate.md
+++ b/can-dom-mutate.md
@@ -1,0 +1,63 @@
+@module {{}} can-dom-mutate
+@parent can-dom-utilities
+@collection can-infrastructure
+
+@description Dispatch and listen for DOM mutations.
+@group can-dom-mutate.static 0 methods
+@group can-dom-mutate/modules 1 modules
+@signature `domMutate`
+
+`can-dom-mutate` exports an object that lets you listen to changes
+in the DOM using the [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
+API.
+
+```js
+import {domMutate} from "can";
+
+domMutate
+// -> {
+//     onAttributeChange( documentElement, callback ),
+//     onInsertion( documentElement, callback ),
+//     onRemoval( documentElement, callback ),
+//     onNodeAttributeChange( node, callback ),
+//     onNodeInsertion( node, callback ),
+//     onNodeRemoval( node, callback )
+//   }
+
+// listen to every attribute change within the document:
+domMutate.onAttributeChange(document.documentElement, function(mutationRecord){
+  mutationRecord.target        //-> <input>
+  mutationRecord.attributeName //-> "name"
+  mutationRecord.oldValue      //-> "Ramiya"
+})
+```
+
+If you want to support browsers that do not support the `MutationObserver` api, use
+[can-dom-mutate/node] to update the DOM. Every module within CanJS should do this:
+
+```js
+var mutate = require('can-dom-mutate/node');
+var el = document.createElement('div');
+
+mutate.appendChild.call(document.body, el);
+```
+
+@body
+
+## Use
+
+
+```js
+import {domMutate, domMutateNode} from "can";
+
+var element = document.createElement("div");
+
+var teardown = domMutate.onNodeInsertion(element, ()=>{
+	console.log("element inserted!");
+});
+
+setTimeout(function(){
+	domMutateNode.appendChild.call(document.body, element);
+},1000);
+```
+@codepen

--- a/node.js
+++ b/node.js
@@ -85,7 +85,7 @@ nodeMethods.forEach(function (methodName) {
 * @signature `mutateNode`
 *
 * Exports an `Object` with methods that shouhld be used to mutate HTML.
-* 
+*
 * ```js
 * var mutateNode = require('can-dom-mutate/node');
 * var el = document.createElement('div');
@@ -185,4 +185,4 @@ var mutationObserverKey = 'MutationObserver';
 setMutateStrategy(globals.getKeyValue(mutationObserverKey));
 globals.onKeyValue(mutationObserverKey, setMutateStrategy);
 
-module.exports = namespace.domMutateNode = mutate;
+module.exports = namespace.domMutateNode = domMutate.node = mutate;

--- a/test.html
+++ b/test.html
@@ -1,4 +1,4 @@
 <!doctype html>
 <title>can-dom-mutate</title>
-<script src="node_modules/steal/steal.js" main="test"></script>
+<script src="node_modules/steal/steal.js" main="can-dom-mutate/test"></script>
 <div id="qunit-fixture"></div>

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -346,14 +346,14 @@ moduleWithoutMutationObserver('can-dom-mutate/node (not in document)', function 
 	test('removeChild on the documentElement', function(assert) {
 		var done = assert.async();
 		var doc1 = document.implementation.createHTMLDocument('doc1');
-
+		getDocument(doc1);
 		var undo = domMutate.onNodeRemoval(doc1.documentElement, function() {
 			assert.ok(true, 'this was called');
 			undo();
 			done();
 		});
 
-		getDocument(doc1);
+
 		node.removeChild.call(doc1, doc1.documentElement);
 		getDocument(document);
 	});


### PR DESCRIPTION
- removes unnecessary batching
- avoids extra list transformations (try to get to unique earlier)
- includes textNodes via `createTreeWalker` if supported
- fixes bug with tearing down duplicate mutation observers if global `MutationObserver` changes 