### PR TITLE
Use regular mutations instead of synthetic ones for "connected" elements.

### DIFF
--- a/-util.js
+++ b/-util.js
@@ -52,7 +52,10 @@ function setIsConnected(global) {
 		};
 }
 setIsConnected(globals.getKeyValue("global"));
-globals.onKeyValue("global", setIsConnected);
+globals.onKeyValue("global", function(global) {
+	setIsConnected(global);
+	module.exports.isConnected = isConnected;
+});
 
 function getChildren (parentNode) {
 	var nodes = [];

--- a/-util.js
+++ b/-util.js
@@ -42,18 +42,25 @@ function isElementNode (node) {
 	return !!(node && node.nodeType === 1);
 }
 
-var isConnected; 
-function setIsConnected(global) {
-	isConnected = 'isConnected' in global.Node.prototype ?
-		function(node) { return node.isConnected; } :
-		function(node) { 
-			var doc = getDocument();
-			return node === doc || contains(doc, node);
-		};
+var isConnected;
+function getIsConnectedFromNode(node) {
+	return node.isConnected;
 }
-setIsConnected(globals.getKeyValue("global"));
-globals.onKeyValue("global", function(global) {
-	setIsConnected(global);
+function getIsConnectedFromDocument(node) { 
+	var doc = node.ownerDocument;
+	// if node *is* the document, ownerDocument is null
+	return doc === null || contains(doc, node);
+}
+
+function setIsConnected(doc) {
+	var node = doc.createTextNode("");
+	isConnected = 'isConnected' in node.constructor.prototype ?
+		getIsConnectedFromNode :
+		getIsConnectedFromDocument;
+}
+setIsConnected(globals.getKeyValue("document"));
+globals.onKeyValue("document", function(doc) {
+	setIsConnected(doc);
 	module.exports.isConnected = isConnected;
 });
 

--- a/-util.js
+++ b/-util.js
@@ -1,6 +1,5 @@
 "use strict";
 var getDocument = require("can-globals/document/document");
-var globals = require("can-globals");
 
 function eliminate(array, item) {
 	var index = array.indexOf(item);
@@ -41,28 +40,6 @@ function isFragment (node) {
 function isElementNode (node) {
 	return !!(node && node.nodeType === 1);
 }
-
-var isConnected;
-function getIsConnectedFromNode(node) {
-	return node.isConnected;
-}
-function getIsConnectedFromDocument(node) { 
-	var doc = node.ownerDocument;
-	// if node *is* the document, ownerDocument is null
-	return doc === null || contains(doc, node);
-}
-
-function setIsConnected(doc) {
-	var node = doc.createTextNode("");
-	isConnected = 'isConnected' in node.constructor.prototype ?
-		getIsConnectedFromNode :
-		getIsConnectedFromDocument;
-}
-setIsConnected(globals.getKeyValue("document"));
-globals.onKeyValue("document", function(doc) {
-	setIsConnected(doc);
-	module.exports.isConnected = isConnected;
-});
 
 function getChildren (parentNode) {
 	var nodes = [];
@@ -184,5 +161,5 @@ module.exports = {
 	getChildren: getChildren,
 	subscription: subscription,
 	addToSet: addToSet,
-	isConnected: isConnected
+	contains: contains
 };

--- a/-util.js
+++ b/-util.js
@@ -1,5 +1,6 @@
 "use strict";
 var getDocument = require("can-globals/document/document");
+var globals = require("can-globals");
 
 function eliminate(array, item) {
 	var index = array.indexOf(item);
@@ -29,15 +30,6 @@ function contains(parent, child){
 	}
 }
 
-function isInDocument (node) {
-	var root = getDocument();
-	if (root === node) {
-		return true;
-	}
-
-	return contains(root, node);
-}
-
 function isDocumentElement (node) {
 	return getDocument().documentElement === node;
 }
@@ -49,6 +41,18 @@ function isFragment (node) {
 function isElementNode (node) {
 	return !!(node && node.nodeType === 1);
 }
+
+var isConnected; 
+function setIsConnected(global) {
+	isConnected = 'isConnected' in global.Node.prototype ?
+		function(node) { return node.isConnected; } :
+		function(node) { 
+			var doc = getDocument();
+			return node === doc || contains(doc, node);
+		};
+}
+setIsConnected(globals.getKeyValue("global"));
+globals.onKeyValue("global", setIsConnected);
 
 function getChildren (parentNode) {
 	var nodes = [];
@@ -162,7 +166,6 @@ function subscription (fn) {
 
 module.exports = {
 	eliminate: eliminate,
-	isInDocument: isInDocument,
 	getDocument: getDocument,
 	isDocumentElement: isDocumentElement,
 	isFragment: isFragment,
@@ -170,5 +173,6 @@ module.exports = {
 	getAllNodes: getAllNodes,
 	getChildren: getChildren,
 	subscription: subscription,
-	addToSet: addToSet
+	addToSet: addToSet,
+	isConnected: isConnected
 };

--- a/can-dom-mutate.js
+++ b/can-dom-mutate.js
@@ -289,10 +289,10 @@ function handleAttributeMutations(mutations) {
 	}
 }
 
-// var treeMutationConfig = {
-// 	subtree: true,
-// 	childList: true
-// };
+var treeMutationConfig = {
+	subtree: true,
+	childList: true
+};
 
 var attributeMutationConfig = {
 	attributes: true,
@@ -314,7 +314,7 @@ function addNodeListener(listenerKey, observerKey, isAttributes) {
 		if (isAttributes) {
 			stopObserving = observeMutations(target, observerKey, attributeMutationConfig, handleAttributeMutations);
 		} else {
-			//stopObserving = observeMutations(DOCUMENT(), observerKey, treeMutationConfig, handleTreeMutations);
+			stopObserving = observeMutations(DOCUMENT(), observerKey, treeMutationConfig, handleTreeMutations);
 		}
 
 		addTargetListener(target, listenerKey, listener);
@@ -491,7 +491,7 @@ domMutate = {
 	onNodeConnected: addNodeConnectedListener,
 	onNodeInsertion: function(){
 		// TODO: remove in prod
-		console.warn("don't use this");
+		console.warn("can-dom-mutate: Use onNodeConnected instead of onNodeInsertion");
 		return addNodeConnectedListener.apply(this, arguments);
 	},
 	/**
@@ -508,7 +508,7 @@ domMutate = {
 	onNodeDisconnected: addNodeDisconnectedListener,
 	onNodeRemoval: function(){
 		// TODO: remove in prod
-		console.warn("don't use this");
+		console.warn("can-dom-mutate: Use onNodeDisconnected instead of onNodeRemoval");
 		return addNodeDisconnectedListener.apply(this, arguments);
 	},
 	/**
@@ -538,7 +538,7 @@ domMutate = {
 	onDisconnected: addDisconnectedListener,
 	onRemoval: function(){
 		// TODO: remove in prod
-		console.warn("don't use this");
+		console.warn("can-dom-mutate: Use onDisconnected instead of onRemoval");
 		return addDisconnectedListener.apply(this, arguments);
 	},
 	/**
@@ -555,7 +555,7 @@ domMutate = {
 	onConnected: addConnectedListener,
 	onInsertion: function(){
 		// TODO: remove in prod
-		console.warn("don't use this");
+		console.warn("can-dom-mutate: Use onConnected instead of onInsertion");
 		return addConnectedListener.apply(this, arguments);
 	},
 	/**

--- a/can-dom-mutate.js
+++ b/can-dom-mutate.js
@@ -589,4 +589,10 @@ domMutate = {
 	onNodeRemoved: addNodeRemovedListener
 };
 
+//!steal-remove-start
+if(process.env.NODE_ENV !== "production") {
+	domMutate.dataStore = dataStore;
+}
+//!steal-remove-end
+
 module.exports = namespace.domMutate = domMutate;

--- a/can-dom-mutate.js
+++ b/can-dom-mutate.js
@@ -6,17 +6,12 @@ var getMutationObserver = require('can-globals/mutation-observer/mutation-observ
 var namespace = require('can-namespace');
 var DOCUMENT = require("can-globals/document/document");
 var canReflect = require("can-reflect");
-// var canSymbol = require("can-symbol");
 
 var util = require('./-util');
 var eliminate = util.eliminate;
 var subscription = util.subscription;
 var isDocumentElement = util.isDocumentElement;
 var getAllNodes = util.getAllNodes;
-
-// var slice = Array.prototype.slice;
-
-// var onRemovedSymbol = canSymbol.for("can.onNodeRemoved");
 
 var domMutate, dispatchInsertion, dispatchRemoval, dispatchAttributeChange;
 var dataStore = new WeakMap();

--- a/node/node-test.js
+++ b/node/node-test.js
@@ -1,6 +1,7 @@
 var unit = require('steal-qunit');
 var domMutate = require('../can-dom-mutate');
 var getDocument = require('can-globals/document/document');
+var isNode = require('can-globals/is-node/is-node');
 var node = require('./node');
 var testUtils = require('../test/test-utils');
 var makeSimpleDocument = require("can-vdom/make-document/make-document");
@@ -16,6 +17,31 @@ function neverCall(assert, obj, methodName) {
 		assert.ok(false, methodName + ' should not be called');
 	});
 }
+
+// browser-only tests.
+if(!isNode()) {
+	unit.module("can-dom-mutate/node document selector");
+	test("isConnected uses isConnected where available", function(assert) {
+		assert.expect(4);
+		var doc = getDocument();
+		var fakenode = {
+			get isConnected() {
+				assert.strictEqual(doc.constructor, getDocument().constructor, "with real document")
+				return true;
+			},
+			get ownerDocument() {
+				assert.notStrictEqual(doc.constructor, getDocument().constructor, "with SimpleDocument")
+				return null;
+			}
+		};
+
+		assert.ok(node.isConnected(fakenode), "Real document connected");
+		getDocument(makeSimpleDocument());
+		assert.ok(node.isConnected(fakenode), "SimpleDocument connected");
+		getDocument(doc);
+	});
+}
+
 
 function onNodeRemovedTest(){
 	test('removeChild dispatches onNodeRemoved', function (assert) {

--- a/node/node-test.js
+++ b/node/node-test.js
@@ -3,6 +3,7 @@ var domMutate = require('../can-dom-mutate');
 var getDocument = require('can-globals/document/document');
 var node = require('./node');
 var testUtils = require('../test/test-utils');
+var makeSimpleDocument = require("can-vdom/make-document/make-document");
 
 var test = unit.test;
 var moduleWithMutationObserver = testUtils.moduleWithMutationObserver;
@@ -16,7 +17,7 @@ function neverCall(assert, obj, methodName) {
 	});
 }
 
-moduleMutationObserver('can-dom-mutate/node', function(){
+function onNodeRemovedTest(){
 	test('removeChild dispatches onNodeRemoved', function (assert) {
 		var done = assert.async();
 		var parent = testUtils.getFixture();
@@ -31,10 +32,11 @@ moduleMutationObserver('can-dom-mutate/node', function(){
 
 		node.removeChild.call(parent, child);
 	});
-});
+}
+moduleMutationObserver('can-dom-mutate/node with real document', getDocument(), onNodeRemovedTest);
+moduleMutationObserver('can-dom-mutate/node with SimpleDocument', makeSimpleDocument(), onNodeRemovedTest);
 
 moduleWithMutationObserver('can-dom-mutate/node', function () {
-	return;
 	QUnit.test('appendChild should not call domMutate.dispatchNodeInsertion', function (assert) {
 		var parent = testUtils.getFixture();
 		var child = document.createElement('div');
@@ -88,8 +90,10 @@ moduleWithMutationObserver('can-dom-mutate/node', function () {
 	});
 
 	QUnit.test('setAttribute should not call domMutate.dispatchNodeAttributeChange', function (assert) {
+		var parent = testUtils.getFixture();
 		var element = document.createElement('div');
 		var undo = neverCall(assert, domMutate, 'dispatchNodeAttributeChange');
+		parent.appendChild(element);
 
 		node.setAttribute.call(element, 'data-foo', 'bar');
 		undo();
@@ -98,8 +102,10 @@ moduleWithMutationObserver('can-dom-mutate/node', function () {
 	});
 
 	QUnit.test('removeAttribute should not call domMutate.dispatchNodeAttributeChange', function (assert) {
+		var parent = testUtils.getFixture();
 		var element = document.createElement('div');
 		var undo = neverCall(assert, domMutate, 'dispatchNodeAttributeChange');
+		parent.appendChild(element);
 
 		node.removeAttribute.call(element, 'data-foo');
 		node.setAttribute.call(element, 'data-foo', 'bar');
@@ -110,11 +116,12 @@ moduleWithMutationObserver('can-dom-mutate/node', function () {
 	});
 });
 
-moduleWithoutMutationObserver('can-dom-mutate/node', function () {
+function withoutMutationObserverTests () {
 	QUnit.test('appendChild should call domMutate.dispatchNodeInsertion', function (assert) {
+		var doc = getDocument();
 		var done = assert.async();
 		var parent = testUtils.getFixture();
-		var child = document.createElement('div');
+		var child = doc.createElement('div');
 
 		var undo = mock(domMutate, 'dispatchNodeInsertion', function (node, callback) {
 			assert.equal(node, child, 'Should pass the child being appended');
@@ -128,10 +135,11 @@ moduleWithoutMutationObserver('can-dom-mutate/node', function () {
 	});
 
 	function getFragmentInsertionTest () {
-		var fragment = document.createDocumentFragment();
-		var child1 = document.createElement('div');
-		var child2 = document.createElement('div');
-		var grandchild = document.createElement('div');
+		var doc = getDocument();
+		var fragment = doc.createDocumentFragment();
+		var child1 = doc.createElement('div');
+		var child2 = doc.createElement('div');
+		var grandchild = doc.createElement('div');
 		fragment.appendChild(child1);
 		fragment.appendChild(child2);
 		child2.appendChild(grandchild);
@@ -162,9 +170,10 @@ moduleWithoutMutationObserver('can-dom-mutate/node', function () {
 
 	QUnit.test('insertBefore should call domMutate.dispatchNodeInsertion', function (assert) {
 		var done = assert.async();
+		var doc = getDocument();
 		var parent = testUtils.getFixture();
-		var sibling = document.createElement('span');
-		var child = document.createElement('div');
+		var sibling = doc.createElement('span');
+		var child = doc.createElement('div');
 
 		var undo = mock(domMutate, 'dispatchNodeInsertion', function (node, callback) {
 			assert.equal(node, child, 'Should pass the child being appended');
@@ -180,8 +189,9 @@ moduleWithoutMutationObserver('can-dom-mutate/node', function () {
 
 	QUnit.test('insertBefore should dispatch fragment children to dispatchNodeInserted', function (assert) {
 		assert.expect(2);
+		var doc = getDocument();
 		var parent = testUtils.getFixture();
-		var sibling = document.createElement('div');
+		var sibling = doc.createElement('div');
 		parent.appendChild(sibling);
 
 		var fragTest = getFragmentInsertionTest();
@@ -191,8 +201,9 @@ moduleWithoutMutationObserver('can-dom-mutate/node', function () {
 
 	QUnit.test('removeChild should call domMutate.dispatchNodeRemoval', function (assert) {
 		var done = assert.async();
+		var doc = getDocument();
 		var parent = testUtils.getFixture();
-		var child = document.createElement('div');
+		var child = doc.createElement('div');
 
 		var undo = mock(domMutate, 'dispatchNodeRemoval', function (node, callback) {
 			assert.equal(node, child, 'Should pass the child being removed');
@@ -208,9 +219,10 @@ moduleWithoutMutationObserver('can-dom-mutate/node', function () {
 
 	QUnit.test('replaceChild should call domMutate.dispatchNodeRemoval+Insertion', function (assert) {
 		var done = assert.async();
+		var doc = getDocument();
 		var parent = testUtils.getFixture();
-		var sibling = document.createElement('span');
-		var child = document.createElement('div');
+		var sibling = doc.createElement('span');
+		var child = doc.createElement('div');
 		var isSiblingRemoved = false;
 
 		var undoRemoval = mock(domMutate, 'dispatchNodeRemoval', function (node, callback) {
@@ -236,8 +248,9 @@ moduleWithoutMutationObserver('can-dom-mutate/node', function () {
 
 	QUnit.test('replaceChild should dispatch fragment children to dispatchNodeInserted', function (assert) {
 		assert.expect(3);
+		var doc = getDocument();
 		var parent = testUtils.getFixture();
-		var sibling = document.createElement('div');
+		var sibling = doc.createElement('div');
 		parent.appendChild(sibling);
 
 		var fragTest = getFragmentInsertionTest();
@@ -253,7 +266,8 @@ moduleWithoutMutationObserver('can-dom-mutate/node', function () {
 
 	QUnit.test('setAttribute should call domMutate.dispatchNodeAttributeChange', function (assert) {
 		var done = assert.async();
-		var element = document.createElement('div');
+		var doc = getDocument();
+		var element = doc.createElement('div');
 		element.setAttribute('data-foo', 'bar');
 
 		var undo = mock(domMutate, 'dispatchNodeAttributeChange', function (node, attributeName, oldAttributeValue, callback) {
@@ -271,7 +285,8 @@ moduleWithoutMutationObserver('can-dom-mutate/node', function () {
 
 	QUnit.test('removeAttribute should call domMutate.dispatchNodeAttributeChange', function (assert) {
 		var done = assert.async();
-		var element = document.createElement('div');
+		var doc = getDocument();
+		var element = doc.createElement('div');
 		element.setAttribute('data-foo', 'bar');
 
 		var undo = mock(domMutate, 'dispatchNodeAttributeChange', function (node, attributeName, oldAttributeValue, callback) {
@@ -286,9 +301,12 @@ moduleWithoutMutationObserver('can-dom-mutate/node', function () {
 
 		node.removeAttribute.call(element, 'data-foo');
 	});
-});
+};
+moduleWithoutMutationObserver('can-dom-mutate/node with real document', getDocument(), withoutMutationObserverTests);
+moduleWithoutMutationObserver('can-dom-mutate/node with SimpleDocument', makeSimpleDocument(), withoutMutationObserverTests);
 
-moduleWithoutMutationObserver('can-dom-mutate/node (not in document)', function () {
+
+function notInDocumentTests() {
 	/*
 		We do not want insertion events to dispatched when a node
 		is inserted into a parent which is not in the document.
@@ -304,8 +322,9 @@ moduleWithoutMutationObserver('can-dom-mutate/node (not in document)', function 
 
 	QUnit.test('appendChild should not call dispatchNodeInsertion', function (assert) {
 		assert.expect(1);
-		var fragment = document.createDocumentFragment();
-		var child = document.createElement('div');
+		var doc = getDocument();
+		var fragment = doc.createDocumentFragment();
+		var child = doc.createElement('div');
 		var undo = mock(domMutate, 'dispatchNodeInsertion', function (el, callback, dispatchConnected) {
 			assert.equal(dispatchConnected, false, 'We should not dispatch connected things');
 		});
@@ -316,9 +335,10 @@ moduleWithoutMutationObserver('can-dom-mutate/node (not in document)', function 
 
 	QUnit.test('insertBefore should not call dispatchNodeInsertion', function (assert) {
 		assert.expect(1);
-		var fragment = document.createDocumentFragment();
-		var child = document.createElement('div');
-		var reference = document.createElement('span');
+		var doc = getDocument();
+		var fragment = doc.createDocumentFragment();
+		var child = doc.createElement('div');
+		var reference = doc.createElement('span');
 		fragment.appendChild(reference);
 
 		var undo = mock(domMutate, 'dispatchNodeInsertion', function (el, callback, dispatchConnected) {
@@ -331,8 +351,9 @@ moduleWithoutMutationObserver('can-dom-mutate/node (not in document)', function 
 
 	QUnit.test('removeChild should not call dispatchNodeRemoval', function (assert) {
 		assert.expect(1);
-		var fragment = document.createDocumentFragment();
-		var child = document.createElement('div');
+		var doc = getDocument();
+		var fragment = doc.createDocumentFragment();
+		var child = doc.createElement('div');
 		fragment.appendChild(child);
 
 		var undo = mock(domMutate, 'dispatchNodeRemoval', function (el, callback, dispatchConnected) {
@@ -345,9 +366,10 @@ moduleWithoutMutationObserver('can-dom-mutate/node (not in document)', function 
 
 	QUnit.test('replaceChild should not call dispatchNodeRemoval+Insertion', function (assert) {
 		assert.expect(2);
-		var fragment = document.createDocumentFragment();
-		var child = document.createElement('div');
-		var oldChild = document.createElement('span');
+		var doc = getDocument();
+		var fragment = doc.createDocumentFragment();
+		var child = doc.createElement('div');
+		var oldChild = doc.createElement('span');
 		fragment.appendChild(oldChild);
 
 		var undoRemoval = mock(domMutate, 'dispatchNodeRemoval', function (el, callback, dispatchConnected) {
@@ -364,7 +386,8 @@ moduleWithoutMutationObserver('can-dom-mutate/node (not in document)', function 
 
 	QUnit.test('removeChild on the documentElement', function(assert) {
 		var done = assert.async();
-		var doc1 = document.implementation.createHTMLDocument('doc1');
+		var doc = getDocument();
+		var doc1 = doc.implementation.createHTMLDocument('doc1');
 		getDocument(doc1);
 		var undo = domMutate.onNodeDisconnected(doc1.documentElement, function() {
 			assert.ok(true, 'this was called');
@@ -374,6 +397,8 @@ moduleWithoutMutationObserver('can-dom-mutate/node (not in document)', function 
 
 
 		node.removeChild.call(doc1, doc1.documentElement);
-		getDocument(document);
+		getDocument(doc);
 	});
-});
+}
+moduleWithoutMutationObserver('can-dom-mutate/node (not in real document)', getDocument(), notInDocumentTests);
+moduleWithoutMutationObserver('can-dom-mutate/node (not in SimpleDocument)', makeSimpleDocument(), notInDocumentTests);

--- a/node/node.js
+++ b/node/node.js
@@ -6,10 +6,10 @@ var domMutate = require('../can-dom-mutate');
 var util = require('../-util');
 
 var getParents = util.getParents;
-var isConnected = util.isConnected;
 
 var compat = {
 	replaceChild: function (newChild, oldChild) {
+		var isConnected = util.isConnected;
 		var newChildren = getParents(newChild);
 		var result = this.replaceChild(newChild, oldChild);
 		domMutate.dispatchNodeRemoval(oldChild, null, isConnected(this) && !isConnected(oldChild));
@@ -43,6 +43,7 @@ var compatData = [
 	['removeChild', 'Removal']
 ];
 compatData.forEach(function (pair) {
+	var isConnected = util.isConnected;
 	var nodeMethod = pair[0];
 	var dispatchMethod = 'dispatchNode' + pair[1];
 	compat[nodeMethod] = function (node) {
@@ -59,7 +60,7 @@ var normal = {};
 var nodeMethods = ['appendChild', 'insertBefore', 'removeChild', 'replaceChild', 'setAttribute', 'removeAttribute'];
 nodeMethods.forEach(function (methodName) {
 	normal[methodName] = function () {
-		if(isConnected(this)) {
+		if(util.isConnected(this)) {
 			return this[methodName].apply(this, arguments);
 		} else {
 			return compat[methodName].apply(this, arguments);

--- a/node/node.js
+++ b/node/node.js
@@ -25,6 +25,13 @@ function setIsConnected(doc) {
 	isConnected = 'isConnected' in node.constructor.prototype ?
 		getIsConnectedFromNode :
 		getIsConnectedFromDocument;
+	//!steal-remove-start
+	if(process.env.NODE_ENV !== "production") {
+		if(mutate) {
+			mutate.isConnected = isConnected;
+		}
+	}
+	//!steal-remove-end
 }
 setIsConnected(globals.getKeyValue("document"));
 globals.onKeyValue("document", setIsConnected);
@@ -198,5 +205,11 @@ function setMutateStrategy(observer) {
 var mutationObserverKey = 'MutationObserver';
 setMutateStrategy(globals.getKeyValue(mutationObserverKey));
 globals.onKeyValue(mutationObserverKey, setMutateStrategy);
+
+//!steal-remove-start
+if(process.env.NODE_ENV !== "production") {
+	mutate.isConnected = isConnected;
+}
+//!steal-remove-end
 
 module.exports = namespace.domMutateNode = domMutate.node = mutate;

--- a/node/node.js
+++ b/node/node.js
@@ -25,13 +25,9 @@ function setIsConnected(doc) {
 	isConnected = 'isConnected' in node.constructor.prototype ?
 		getIsConnectedFromNode :
 		getIsConnectedFromDocument;
-	//!steal-remove-start
-	if(process.env.NODE_ENV !== "production") {
-		if(mutate) {
-			mutate.isConnected = isConnected;
-		}
+	if(mutate) {
+		mutate.isConnected = isConnected;
 	}
-	//!steal-remove-end
 }
 setIsConnected(globals.getKeyValue("document"));
 globals.onKeyValue("document", setIsConnected);
@@ -194,7 +190,6 @@ var mutate = {};
 */
 
 function setMutateStrategy(observer) {
-	// TODO: later make this workable ...
 	var strategy = observer ? normal : compat;
 
 	for (var key in strategy) {
@@ -206,10 +201,6 @@ var mutationObserverKey = 'MutationObserver';
 setMutateStrategy(globals.getKeyValue(mutationObserverKey));
 globals.onKeyValue(mutationObserverKey, setMutateStrategy);
 
-//!steal-remove-start
-if(process.env.NODE_ENV !== "production") {
-	mutate.isConnected = isConnected;
-}
-//!steal-remove-end
+mutate.isConnected = isConnected;
 
 module.exports = namespace.domMutateNode = domMutate.node = mutate;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "devDependencies": {
     "can-dom-events": "^1.3.0",
+    "can-simple-dom": "^1.6.2",
+    "can-vdom": "^4.4.1",
     "fixpack": "^2.3.1",
     "jshint": "^2.9.1",
     "steal": "^1.3.1",

--- a/test/can-dom-mutate-test.js
+++ b/test/can-dom-mutate-test.js
@@ -66,17 +66,19 @@ function mutationObserverTests() {
 		node.setAttribute.call(child, attributeName, 'baz');
 	});
 
-	test('onInserted should be called when any node is inserted', function (assert) {
+	test('onConnected should be called when any node is inserted', function (assert) {
 		var done = assert.async();
 		var parent = testUtils.getFixture();
 		var doc = globals.getKeyValue('document');
 		var child = doc.createElement('div');
 
 		var undo = domMutate.onConnected(doc.documentElement, function (mutation) {
-			assert.equal(mutation.target, child, 'Node should be the inserted child');
+			if(mutation.target === child) {
+				assert.ok(true, 'Node should be the inserted child');
 
-			undo();
-			done();
+				undo();
+				done();
+			}
 		});
 
 		node.appendChild.call(parent, child);
@@ -130,10 +132,12 @@ function mutationObserverTests() {
 		var child = doc.createElement('div');
 
 		var undo = domMutate.onDisconnected(doc.documentElement, function (mutation) {
-			assert.equal(mutation.target, child, 'Node should be the removed child');
+			if(mutation.target === child) {
+				assert.ok(true, 'Node should be the removed child');
 
-			undo();
-			done();
+				undo();
+				done();
+			}
 		});
 
 		parent.appendChild(child);


### PR DESCRIPTION
Native mutation dispatch is now used when the parent element is in the document, while preserving synthetic mutations for subtrees of disconnected elements.
