### PR TITLE
Fix leak with listeners that aren't manually disposed

### DIFF
--- a/benchmark/memory.html
+++ b/benchmark/memory.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<title>Memory tests</title>
+<style>
+	body {
+		font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+	}
+
+	button {
+		font-size: 200%;
+		background: salmon;
+		border: 2px solid black;
+		color: black;
+		padding: .5em 1em;
+		cursor: pointer;
+	}
+
+	#runner {
+		text-align: center;
+	}
+</style>
+<h1>onNodeDisconnected memory leak</h1>
+<p>This tests a leak in using domMutate#onNodeDisconnected when the element is never inserted into the page. Use the devtools memory tool and click <strong>run me</strong>. Every time you click run a new element is created. Hopefully there are no leaks.</p>
+<div id="runner">
+	<button type="button">Run me</button>
+</div>
+<div id="root"></div>
+<script src="../node_modules/steal/steal.js"></script>
+<script type="steal-module">
+	var domMutate = require("can-dom-mutate");
+	var DOCUMENT = require("can-globals/document/");
+	// var nodeLists = require("can-view-nodelist");
+
+	function run() {
+		var doc = document.implementation.createHTMLDocument();
+		var div = doc.createElement("div");
+		DOCUMENT(doc);
+		domMutate.onNodeDisconnected(div, function() {});
+		//domMutate.onNodeAttributeChange(div, function() {});
+		DOCUMENT(document);
+	}
+
+	document.querySelector('button').addEventListener('click', run);
+</script>

--- a/can-dom-mutate.js
+++ b/can-dom-mutate.js
@@ -77,7 +77,7 @@ function addTargetListener (target, key, listener) {
 	var doc = DOCUMENT();
 	var targetListenersMap = getRelatedData(doc, key);
 	if (!targetListenersMap) {
-		targetListenersMap = new Map();
+		targetListenersMap = new WeakMap();
 		setRelatedData(doc, key, targetListenersMap);
 	}
 	var targetListeners = targetListenersMap.get(target);


### PR DESCRIPTION
Also add benchmark page for testing out improvements to memory usage.

NB: the data store can be accessed from the console in the benchmark page like this:

```
> can = await System.import("can-namespace")
> can.domMutate.dataStore
```