### PR TITLE
Don't listen for changes to the mutation observer

### DIFF
--- a/can-dom-mutate.js
+++ b/can-dom-mutate.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var globals = require('can-globals');
 var getRoot = require('can-globals/global/global');
 var getMutationObserver = require('can-globals/mutation-observer/mutation-observer');
 var namespace = require('can-namespace');

--- a/can-dom-mutate.js
+++ b/can-dom-mutate.js
@@ -218,7 +218,6 @@ function observeMutations(target, observerKey, config, handler) {
 	};
 
 	if (observerData.observingCount === 0) {
-		globals.onKeyValue('MutationObserver', setupObserver);
 		setupObserver();
 	}
 
@@ -232,7 +231,6 @@ function observeMutations(target, observerKey, config, handler) {
 					observerData.observer.disconnect();
 				}
 				deleteRelatedData(target, observerKey);
-				globals.offKeyValue('MutationObserver', setupObserver);
 			}
 		}
 	};


### PR DESCRIPTION
This prevents leaking when not all bindings are manually torn down.  Now that we're using WeakMaps for the data stores, users do not have to tear down every mutation binding manually to avoid leaks, but we would still have a potential leak with every node listening to the mutation observer global changing.

It doesn't break our tests, surprisingly, and users will likely never change the MO constructor during normal operation, so let's remove it.