### PR TITLE
Queued mutations

### DIFF
--- a/node/node-test.js
+++ b/node/node-test.js
@@ -31,7 +31,7 @@ test("isConnected() uses isConnected where available", function(assert) {
 				assert.notStrictEqual(doc.constructor, getDocument().constructor, "with SimpleDocument")
 			} else {
 				// IE 11 doesn't support isConnected, so both isConnected() calls will go through here
-				assert.ok(true, "Native Node.prototype does not support isConnected");					
+				assert.ok(true, "Native Node.prototype does not support isConnected");
 			}
 			return null;
 		}
@@ -411,7 +411,7 @@ function notInDocumentTests() {
 		undoInsertion();
 	});
 
-	QUnit.test('removeChild on the documentElement', function(assert) {
+	QUnit.only('removeChild on the documentElement', function(assert) {
 		var done = assert.async();
 		var doc = getDocument();
 		var doc1 = doc.implementation.createHTMLDocument('doc1');

--- a/node/node-test.js
+++ b/node/node-test.js
@@ -411,20 +411,22 @@ function notInDocumentTests() {
 		undoInsertion();
 	});
 
-	QUnit.only('removeChild on the documentElement', function(assert) {
+	QUnit.test('removeChild on the documentElement', function(assert) {
 		var done = assert.async();
 		var doc = getDocument();
 		var doc1 = doc.implementation.createHTMLDocument('doc1');
 		getDocument(doc1);
+
 		var undo = domMutate.onNodeDisconnected(doc1.documentElement, function() {
 			assert.ok(true, 'this was called');
+			getDocument(doc);
 			undo();
 			done();
 		});
 
 
 		node.removeChild.call(doc1, doc1.documentElement);
-		getDocument(doc);
+
 	});
 }
 moduleWithoutMutationObserver('can-dom-mutate/node (not in real document)', getDocument(), notInDocumentTests);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "can-vdom": "^4.4.1",
     "fixpack": "^2.3.1",
     "jshint": "^2.9.1",
-    "steal": "^1.3.1",
+    "steal": "^2.0.0",
     "steal-qunit": "^2.0.0",
     "steal-tools": "^1.2.0",
     "testee": "^0.9.0"

--- a/test.html
+++ b/test.html
@@ -1,4 +1,4 @@
 <!doctype html>
 <title>can-dom-mutate</title>
-<script src="node_modules/steal/steal.js" main="can-dom-mutate/test"></script>
+<script src="node_modules/steal/steal.js" main="~/test"></script>
 <div id="qunit-fixture"></div>

--- a/test.js
+++ b/test.js
@@ -1,3 +1,3 @@
 import './test/can-dom-mutate-test';
-//import './events/events-test';
-//import './node/node-test';
+import './events/events-test';
+import './node/node-test';


### PR DESCRIPTION
This makes all mutations use an internal queuing mechanism.

This makes sure that any `domMutate.flushRecords()` calls, called during dispatching of mutations, will:

- happen in the right order
- avoid duplicate connected / disconnected calls

There's a decent amount of cleanup that should happen after this. Specifically:

- the queue system should probably be pulled out into its own file
- Instead of getting `var doc = DOCUMENT();`, the target's ownerDocument should be used.
- `handleAttributeMutation` and `dispatchAttributeChange` should be cleaned up