### PR TITLE
Disconnect MutationObserver when can-globals key changes

### DIFF
--- a/can-dom-mutate.js
+++ b/can-dom-mutate.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var globals = require('can-globals');
 var getRoot = require('can-globals/global/global');
 var getMutationObserver = require('can-globals/mutation-observer/mutation-observer');
 var namespace = require('can-namespace');

--- a/can-dom-mutate.js
+++ b/can-dom-mutate.js
@@ -51,15 +51,6 @@ function deleteRelatedData(node, key) {
 function toMutationEvent(node, mutation) {
 	return {target: node, sourceMutation: mutation};
 }
-/*
-function toMutationEvents (nodes) {
-	var events = [];
-	for (var i = 0, length = nodes.length; i < length; i++) {
-		events.push({target: nodes[i]});
-	}
-	return events;
-}
-*/
 
 function getDocumentListeners (target, key) {
 	// TODO: it's odd these functions read DOCUMENT() instead of
@@ -130,41 +121,15 @@ function flushCallbacks(callbacks, arg){
 		safeCallbacks[c](arg);
 	}
 }
-/*
-function flushRecords(){
-	if(recordsAndCallbacks === null) {
-		return;
-	}
-	var safeBatch = recordsAndCallbacks;
-	recordsAndCallbacks = null;
 
-	var batchCount = safeBatch.length;
-
-	for (var i = 0; i < batchCount; i++) {
-		var batchData = safeBatch[i];
-		flushCallbacks(batchData.callbacks, batchData.arg);
-	}
-}
-
-function flushAsync(callbacks, arg) {
-	if(recordsAndCallbacks === null) {
-		recordsAndCallbacks = [{arg: arg, callbacks: callbacks}];
-		nextTick(flushRecords);
-	} else {
-		recordsAndCallbacks.push({arg: arg, callbacks: callbacks});
-	}
-}
-*/
 function dispatch(getListeners, targetKey) {
 
 	return function dispatchEvents(event) {
-
 		var targetListeners = getListeners(event.target, targetKey);
 
 		if (targetListeners) {
 			flushCallbacks(targetListeners, event);
 		}
-
 	};
 }
 
@@ -220,68 +185,6 @@ function observeMutations(target, observerKey, config, handler) {
 		}
 	};
 }
-/*
-function handleTreeMutations(mutations) {
-	// in IE11, if the document is being removed
-	// (such as when an iframe is added and then removed)
-	// all of the global constructors will not exist
-	// If this happens before a tree mutation is handled,
-	// this will throw an `Object expected` error.
-	if (typeof Set === "undefined") { return; }
-
-	if(this.flushing === true) {
-		this.mutations.push.apply(this.mutations, mutations);
-		return;
-	}
-	this.flushing = true;
-	this.mutations = [].slice.call(mutations);
-
-	var mutation;
-
-	var mutationCount = mutations.length;
-	var added = new Set(), removed = new Set();
-
-	while(mutation = this.mutations.shift()) {
-		var removedCount = mutation.removedNodes.length;
-		for (var r = 0; r < removedCount; r++) {
-			// get what already isn't in `removed`
-			var newRemoved = util.addToSet( getAllNodes(mutation.removedNodes[r]), removed);
-			dispatchRemoval( newRemoved.map(toMutationEvent), null, true, flushCallbacks );
-		}
-
-		var addedCount = mutation.addedNodes.length;
-		for (var a = 0; a < addedCount; a++) {
-			var newAdded = util.addToSet( getAllNodes(mutation.addedNodes[a]), added);
-			dispatchInsertion( newAdded.map(toMutationEvent), null, true, flushCallbacks );
-		}
-
-	}
-
-	this.flushing = false;
-	//dispatchRemoval( toMutationEvents( canReflect.toArray(removed) ), null, true, flushCallbacks );
-	//dispatchInsertion( toMutationEvents( canReflect.toArray(added) ), null, true, flushCallbacks );
-}
-
-function handleAttributeMutations(mutations) {
-	var mutationCount = mutations.length;
-	for (var m = 0; m < mutationCount; m++) {
-		var mutation = mutations[m];
-		if (mutation.type === 'attributes') {
-			var node = mutation.target;
-			var attributeName = mutation.attributeName;
-			var oldValue = mutation.oldValue;
-			dispatchAttributeChange([{
-				target: node,
-				attributeName: attributeName,
-				oldValue: oldValue
-			}], null, true, flushCallbacks);
-		}
-	}
-}
-*/
-
-
-
 
 var treeMutationConfig = {
 	subtree: true,
@@ -457,10 +360,6 @@ function dispatchTreeMutation(mutation, processedState) {
 	}
 	// run mutation
 }
-
-
-
-
 
 
 var FLUSHING_MUTATIONS = [];

--- a/can-dom-mutate.js
+++ b/can-dom-mutate.js
@@ -201,6 +201,7 @@ function observeMutations(target, observerKey, config, handler) {
 	};
 
 	if (observerData.observingCount === 0) {
+		globals.onKeyValue('MutationObserver', setupObserver);
 		setupObserver();
 	}
 
@@ -214,6 +215,7 @@ function observeMutations(target, observerKey, config, handler) {
 					observerData.observer.disconnect();
 				}
 				deleteRelatedData(target, observerKey);
+				globals.offKeyValue('MutationObserver', setupObserver);
 			}
 		}
 	};

--- a/node/node.js
+++ b/node/node.js
@@ -179,6 +179,4 @@ var mutationObserverKey = 'MutationObserver';
 setMutateStrategy(globals.getKeyValue(mutationObserverKey));
 globals.onKeyValue(mutationObserverKey, setMutateStrategy);
 
-//mutate.isConnected = isConnected;
-
 module.exports = namespace.domMutateNode = domMutate.node = mutate;


### PR DESCRIPTION
The new tests rely on the ability to disable MutationObservers to detect the "compat" path. Because can-view-live sets up an initial MutationObserver, not having a method to disconnect them leaves to some DOM events to occur twice (once the synthetic way and once through MO).  To fix the tests we need to bring back adding the globals listener.

