### PR TITLE
Work around IE11 contains() that does not recognize text nodes

### DIFF
--- a/-util.js
+++ b/-util.js
@@ -17,6 +17,9 @@ function wasNotInSet(item, set) {
 
 
 function contains(parent, child){
+	if(child && child.nodeType === Node.TEXT_NODE) {
+		return contains(parent, child.parentNode);
+	}
 	if(parent.contains) {
 		return parent.contains(child);
 	}


### PR DESCRIPTION
In IE11, `HTMLElement.prototype.contains` always returns `false` if the argument is a text node.  The `isConnected` polyfill in can-dom-mutate already does some IE-specific polyfill on the presence of `Node.prototype.contains` for IE and can-vdom, so in this PR the polyfill is extended to look at the parent node instead if a text node is passed in.